### PR TITLE
FB 自動追加的 &fbclid=XXX 干擾題號判別

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ var uvaUrl,lcatUrl;
 var hasLcat = true;
 window.onload = function() {
 	var urlGet = decodeURIComponent(window.location.search.substring(1)).split("/");
-	probnum = urlGet[0].replace(/[^0-9]/g,"");
+	probnum = (urlGet[0].match(/[0-9]+/g) ?? [0])[0];
 	userId = urlGet[1];
 	$.getJSON("https://uhunt.onlinejudge.org/api/p/num/"+probnum, loadProb);
 	$.get("lcat.csv", loadLcatDetail);


### PR DESCRIPTION


從 FB 點擊會帶一串 &fbclid=XXXX 之類的垃圾
原邏輯會刪去所有非數字的字元，這會留下fbclid所帶來的垃圾 digit 導致題號判別有誤
我想題號也沒有合併四處分散的digits的必要性，就想說改成找出第一組連續數字作為題號
找不到時的預設沒啥想法，就先隨便以 0 作為預設值了